### PR TITLE
Create a default org at a startup time

### DIFF
--- a/deployments/server/templates/configmap.yaml
+++ b/deployments/server/templates/configmap.yaml
@@ -9,6 +9,10 @@ data:
     httpPort: {{ .Values.httpPort }}
     grpcPort: {{ .Values.grpcPort }}
     internalGrpcPort: {{ .Values.internalGrpcPort }}
+    defaultOrganization:
+      title: {{ .Values.defaultOrganization.title }}
+      userIds:
+      {{- toYaml .Values.defaultOrganization.userIds | nindent 6 }}
     database:
       host: {{ .Values.global.database.host }}
       port: {{ .Values.global.database.port }}

--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -22,6 +22,11 @@ internalGrpcPort: 8082
 database:
   database: user_manager
 
+defaultOrganization:
+  title: default
+  userIds:
+  - admin@example.com
+
 replicaCount: 1
 image:
   repository: public.ecr.aws/v8n3t7y5/llm-operator/user-manager-server

--- a/server/cmd/run.go
+++ b/server/cmd/run.go
@@ -87,10 +87,17 @@ func run(ctx context.Context, c *config.Config) error {
 		errCh <- http.ListenAndServe(fmt.Sprintf(":%d", c.HTTPPort), mux)
 	}()
 
+	s := server.New(st)
 	go func() {
-		s := server.New(st)
 		errCh <- s.Run(ctx, c.GRPCPort, c.AuthConfig)
 	}()
+
+	if do := &c.DefaultOrganization; do.Title != "" {
+		log.Printf("Creating default org %q", do.Title)
+		if err := s.CreateDefaultOrganization(ctx, do); err != nil {
+			return err
+		}
+	}
 
 	go func() {
 		s := server.NewInternal(st)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -8,6 +8,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// DefaultOrganizationConfig is the default organization configuration.
+type DefaultOrganizationConfig struct {
+	Title   string   `yaml:"title"`
+	UserIDs []string `yaml:"userIds"`
+}
+
 // DebugConfig is the debug configuration.
 type DebugConfig struct {
 	Standalone bool   `yaml:"standalone"`
@@ -38,6 +44,8 @@ type Config struct {
 	InternalGRPCPort int `yaml:"internalGrpcPort"`
 
 	Database db.Config `yaml:"database"`
+
+	DefaultOrganization DefaultOrganizationConfig `yaml:"defaultOrganization"`
 
 	Debug DebugConfig `yaml:"debug"`
 

--- a/server/internal/server/org_test.go
+++ b/server/internal/server/org_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	v1 "github.com/llm-operator/user-manager/api/v1"
+	"github.com/llm-operator/user-manager/server/internal/config"
 	"github.com/llm-operator/user-manager/server/internal/store"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
@@ -58,4 +59,34 @@ func TestOrganization(t *testing.T) {
 	laresp2, err := isrv.store.ListAllOrganizationUsers()
 	assert.NoError(t, err)
 	assert.Len(t, laresp2, 1)
+}
+
+func TestCreateDefaultOrganization(t *testing.T) {
+	st, tearDown := store.NewTest(t)
+	defer tearDown()
+
+	srv := New(st)
+	c := &config.DefaultOrganizationConfig{
+		Title: "default",
+		UserIDs: []string{
+			"admin",
+		},
+	}
+	err := srv.CreateDefaultOrganization(context.Background(), c)
+	assert.NoError(t, err)
+
+	o, err := st.GetOrganizationByTenantIDAndTitle(fakeTenantID, "default")
+	assert.NoError(t, err)
+
+	users, err := st.ListAllOrganizationUsers()
+	assert.NoError(t, err)
+	assert.Len(t, users, 1)
+	u := users[0]
+	assert.Equal(t, o.OrganizationID, u.OrganizationID)
+	assert.Equal(t, "admin", u.UserID)
+	assert.Equal(t, v1.Role_OWNER.String(), u.Role)
+
+	// Calling again is no-op.
+	err = srv.CreateDefaultOrganization(context.Background(), c)
+	assert.NoError(t, err)
 }

--- a/server/internal/store/org.go
+++ b/server/internal/store/org.go
@@ -9,10 +9,10 @@ import (
 type Organization struct {
 	gorm.Model
 
-	TenantID       string `gorm:"index"`
+	TenantID       string `gorm:"index;uniqueIndex:idx_orgs_tenant_id_title"`
 	OrganizationID string `gorm:"uniqueIndex"`
 
-	Title string
+	Title string `gorm:"uniqueIndex:idx_orgs_tenant_id_title"`
 }
 
 // ToProto converts the organization to proto.
@@ -41,6 +41,15 @@ func (s *S) CreateOrganization(tenantID, orgID, title string) (*Organization, er
 func (s *S) GetOrganization(orgID string) (*Organization, error) {
 	var org Organization
 	if err := s.db.Where("organization_id = ?", orgID).First(&org).Error; err != nil {
+		return nil, err
+	}
+	return &org, nil
+}
+
+// GetOrganizationByTenantIDAndTitle gets an organization ID and a title.
+func (s *S) GetOrganizationByTenantIDAndTitle(tenantID, title string) (*Organization, error) {
+	var org Organization
+	if err := s.db.Where("tenant_id = ? AND title = ?", tenantID, title).First(&org).Error; err != nil {
 		return nil, err
 	}
 	return &org, nil


### PR DESCRIPTION
Otherwise it's difficult to bootstrap the entire stack since there is no way to make an RPC call. We need to directly manipulate DB records.