### PR TITLE
Add a TODO comment on scope

### DIFF
--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -38,6 +38,7 @@ func (s *S) Run(ctx context.Context, port int, authConfig config.AuthConfig) err
 
 	var opts []grpc.ServerOption
 	if authConfig.Enable {
+		// TODO(kenji): Change the scope depending on RPC methods.
 		ai, err := auth.NewInterceptor(ctx, authConfig.RBACInternalServerAddr, "api.users.api_keys")
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently we always use "api.users.api_keys", but the scope should be different for org related methods.