### PR TITLE
Create a default user when a new org is created

### DIFF
--- a/server/internal/server/org_test.go
+++ b/server/internal/server/org_test.go
@@ -29,6 +29,13 @@ func TestOrganization(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, title, cresp.Title)
 
+		// Delete the default user to make the rest of the test simple.
+		_, err = srv.DeleteOrganizationUser(ctx, &v1.DeleteOrganizationUserRequest{
+			OrganizationId: cresp.Id,
+			UserId:         defaultUserID,
+		})
+		assert.NoError(t, err)
+
 		_, err = srv.CreateOrganizationUser(ctx, &v1.CreateOrganizationUserRequest{
 			OrganizationId: cresp.Id,
 			UserId:         "user 1",
@@ -174,6 +181,13 @@ func TestListOrganizationUsers(t *testing.T) {
 		assert.NoError(t, err)
 		orgs = append(orgs, org)
 
+		// Delete the default user to make the rest of the test simple.
+		_, err = srv.DeleteOrganizationUser(ctx, &v1.DeleteOrganizationUserRequest{
+			OrganizationId: org.Id,
+			UserId:         defaultUserID,
+		})
+		assert.NoError(t, err)
+
 		_, err = srv.CreateOrganizationUser(ctx, &v1.CreateOrganizationUserRequest{
 			OrganizationId: org.Id,
 			UserId:         fmt.Sprintf("user %d", i),
@@ -201,6 +215,13 @@ func TestDeleteDeleteOrganizationUser(t *testing.T) {
 
 	o, err := srv.CreateOrganization(ctx, &v1.CreateOrganizationRequest{
 		Title: "title",
+	})
+	assert.NoError(t, err)
+
+	// Delete the default user to make the rest of the test simple.
+	_, err = srv.DeleteOrganizationUser(ctx, &v1.DeleteOrganizationUserRequest{
+		OrganizationId: o.Id,
+		UserId:         defaultUserID,
 	})
 	assert.NoError(t, err)
 

--- a/server/internal/server/project_test.go
+++ b/server/internal/server/project_test.go
@@ -90,6 +90,13 @@ func TestProjectUser(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	// Delete the default user to make the rest of the test simple.
+	_, err = srv.DeleteOrganizationUser(ctx, &v1.DeleteOrganizationUserRequest{
+		OrganizationId: org.Id,
+		UserId:         defaultUserID,
+	})
+	assert.NoError(t, err)
+
 	proj, err := srv.CreateProject(ctx, &v1.CreateProjectRequest{
 		Title:               "Test project",
 		OrganizationId:      org.Id,
@@ -216,6 +223,13 @@ func TestCreateDefaultProject(t *testing.T) {
 
 	org, err := srv.CreateOrganization(ctx, &v1.CreateOrganizationRequest{
 		Title: "Test organization",
+	})
+	assert.NoError(t, err)
+
+	// Delete the default user to make the rest of the test simple.
+	_, err = srv.DeleteOrganizationUser(ctx, &v1.DeleteOrganizationUserRequest{
+		OrganizationId: org.Id,
+		UserId:         defaultUserID,
 	})
 	assert.NoError(t, err)
 

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	defaultProjectID = "default"
+	defaultUserID    = "defaultUser"
+	defaultProjectID = "defaultProject"
 )
 
 // New creates a server.
@@ -100,6 +101,7 @@ func (s *S) Stop() {
 func (s *S) extractUserInfoFromContext(ctx context.Context) (*auth.UserInfo, error) {
 	if !s.enableAuth {
 		return &auth.UserInfo{
+			UserID:              defaultUserID,
 			OrganizationID:      "default",
 			ProjectID:           defaultProjectID,
 			KubernetesNamespace: "default",


### PR DESCRIPTION
Otherwise there is no owner in the new org, and no one can access.