### PR TITLE
Normalize user IDs

### DIFF
--- a/pkg/userid/normalize.go
+++ b/pkg/userid/normalize.go
@@ -1,0 +1,8 @@
+package userid
+
+import "strings"
+
+// Normalize normalizes the user ID (= email address) to lowercase.
+func Normalize(userID string) string {
+	return strings.ToLower(userID)
+}


### PR DESCRIPTION
We use email addresses as user IDs, we hit a case where a registered user ID has all lower characters while an actual email address in JWT contains capital letters.

Always lower user IDs to avoid hitting such a case.